### PR TITLE
Renames Carcassonne to Ore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # Environment ------------------------------------------------------------------ 
-CARCASSONNE_HOME=$(shell pwd)
+PROJECT_HOME=$(shell pwd)
 TMPDIR=/tmp
 PATH=${TMPDIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PROJECT_BIN_MAIN=${PROJECT_HOME}/ore
+PROJECT_BIN_TESTED=${TMPDIR}/ore-dev
 # Configuration ----------------------------------------------------------------
 CLITEST_REPOSITORY_URL="https://github.com/aureliojargas/clitest"
 CLITEST_BIN_URL="https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest"
-CLITEST_BIN=${CARCASSONNE_HOME}/clitest
-CARCASSONNE_DEV=${TMPDIR}/carcassonne-dev
+CLITEST_BIN=${PROJECT_HOME}/clitest
 # Minimum requirement programs -------------------------------------------------
 CURL=$(shell which curl)
 # List of test files to execute in order ---------------------------------------
@@ -14,15 +15,16 @@ TESTS=$(shell find tests -type f -name "*.md")
 
 .PHONY: test $(TESTS)
 
-.carcassonne:
-	@rm -f "${CARCASSONNE_DEV}"
-	@ln -s "${CARCASSONNE_HOME}/carcassonne" "${CARCASSONNE_DEV}"
+.bin:
+	@rm -f "${PROJECT_BIN_TESTED}"
+	ln -s "${PROJECT_BIN_MAIN}" "${PROJECT_BIN_TESTED}"
+	@echo "PATH=${PATH}"
 
 .dependency-clitest:
 	@test -f "${CLITEST_BIN}" || ${CURL} -sL -o "${CLITEST_BIN}" https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
 	@chmod a+x "${CLITEST_BIN}"
 
-$(TESTS): .dependency-clitest .carcassonne
+$(TESTS): .dependency-clitest .bin
 	export TEST_SHELL=${TEST_SHELL:-"sh"}
 	${TEST_SHELL} ${CLITEST_BIN} --prefix 4 $@
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,65 @@
-# Carcassonne: Merging `dotfiles` together
+# Ore: Merging `dotfiles` together
 
 A way to provide (a simple standard) and merge (a program) `dotfiles`.
 Multiple repositories might need to affect the same file (e.g `~/.bashrc`),
-Carcassonne allows that.
+Ore allows that.
 
-Carcassonne is two things:
+Ore is two things:
 
 1. A *Standard* for [dotfiles repositories][d] to follow and play nice together
-1. A program to merge [carcassonne-compatible][m] `dotfiles` together
+1. A program to merge [ore-compatible][m] `dotfiles` together
 
 [d]: https://wiki.archlinux.org/index.php/Dotfiles
-[m]: https://github.com/topics/carcassone "Search compatible repositories"
+[m]: https://github.com/topics/castle-ore "Search compatible repositories"
 
 ## The Standard
 
-Every *carcassonne repository* CAN be a [castle][c], which means:
+Every *ore repository* CAN be a [castle][c], which means:
 
 * They contain a `home` directory
 * `home` contains files which will be symlinked to the user\'s home
 
-*Carcassonne castles* follow just one more rule:
+*Ore castles* follow just one more rule:
 
 * They don\'t have files which might be used by other castles
 
 If you have a castle with `.bashrc` and want to provide it, append
 `_<id>` to the file name: `.bashrc_phpbrew`.
 
-You can search for [other Carcassonne compatible repositories on GitHub][m].
+You can search for [other Ore compatible repositories on GitHub][m].
 
 [c]: https://github.com/technicalpickles/homesick "Homesick: Take your $HOME"
 
 ## The program
 
-The `carcarssonne` command line is used to merge files from smaller
+The `ore` command line is used to merge files from smaller
 ones:
 
-    $ carcassone ".ssh/config_*" > ~/.ssh/config
+    $ ore ".ssh/config_*" > ~/.ssh/config
 
 The execution above will `find` all files in your `$HOME` that start with
-`.ssh/config_` and output its contents to `~/.ssh/config`. `carcassonne` just
+`.ssh/config_` and output its contents to `~/.ssh/config`. `ore` just
 concatenate files and you are responsible for telling which file they will
 produce, a couple more examples:
 
-    $ carcassone ".bashrc_*" > ~/.bashrc
-    $ carcassone ".bash_environment_*" > ~/.bash_environment
-    $ carcassone ".vimrc_*" > ~/.vimrc
+    $ ore ".bashrc_*" > ~/.bashrc
+    $ ore ".bash_environment_*" > ~/.bash_environment
+    $ ore ".vimrc_*" > ~/.vimrc
 
-The files concatenated by `carcassonne` are sorted, meaning `.vimrc_00-pathogen`
+The files concatenated by `ore` are sorted, meaning `.vimrc_00-pathogen`
 is output before `.vimrc_99-papercolor-colorscheme`.
 
 ## Automating things with hooks
 
-A *carcassonne repository* can help you by providing three hooks: 
+A *ore repository* can help you by providing three hooks: 
 
-* `pre-command` and `post-command` are executed before or after `carcassonne`
+* `pre-command` and `post-command` are executed before or after `ore`
 * `load` is used to automatically generate files provided by the repository
 
-**Hooks** MUST be provided inside a `.carcassonne`
+**Hooks** MUST be provided inside a `.ore`
 directory. If the repository is a [castle][c], then it will have a
-`home/.carcassonne` directory. A hook is a *shell* file that is executed by
-`carcassonne` and follow the convention `<when>_<_id>`:
+`home/.ore` directory. A hook is a *shell* file that is executed by
+`ore` and follow the convention `<when>_<_id>`:
 
 * `when`: Is either `pre`, `post` or `load`
 * `id` is usually the name of your repository
@@ -73,33 +73,33 @@ The `load` hook is a text file with the file names provided by the repository
 after they are merged. If a repository provides `~/.vimrc` and has a
 `~/.vimrc_nice-statusbar` then the hook file content can be:
 
-    # ~/.carcassonne/load_nice-statusbar
+    # ~/.ore/load_nice-statusbar
     # Comments are ignored
-    carcassonne "$HOME/.vimrc_* >> $HOME/.vimrc
+    ore "$HOME/.vimrc_* >> $HOME/.vimrc
 
-The `load` hook is only used when you execute `carcassonne` without any
-argument (or `carcassonne --only-load`). All `load` hooks differ from `pre` and
+The `load` hook is only used when you execute `ore` without any
+argument (or `ore --only-load`). All `load` hooks differ from `pre` and
 `post` hooks as their content is first read, merged together with all other
 `load` hook-scripts available so they can be de-duplicated.
 
 ### Pre and Post hooks
 
 This hooks must be executable, they can be a *shell script* or program that gets
-executed by `carcarssonne` if the user accepts the risks involved.
+executed by `ore` if the user accepts the risks involved.
 
 ## Installation
 
-Carcassonne is a single script program, just put it in your `$PATH` or:
+Ore is a single script program, just put it in your `$PATH` or:
 
-    $ sh <(curl -sSL http://git.io/sinister) -u http://git.io/carcassonne
+    $ sh <(curl -sSL http://git.io/sinister) -u http://git.io/ore
 
-The above command, after executed, should provide you with a `carcassonne`
+The above command, after executed, should provide you with a `ore`
 command which you will use. To check if installation was successful, you
 can:
 
-    $ carcassonne --version
-    Carcassonne 1.0.0
+    $ ore --version
+    Ore 1.0.0
 
 If this fails, please [let me know][bugs].
 
-[bugs]: https://github.com/augustohp/carcassonne/issues "Submit a bug report"
+[bugs]: https://github.com/augustohp/ore/issues "Submit a bug report"

--- a/ore
+++ b/ore
@@ -28,11 +28,11 @@ command_help ()
 	       ${NAME} <pattern>
 	       ${NAME}
 	
-	Carcassonne finds files following a "pattern" and outputs their content
+	Ore finds files following a "pattern" and outputs their content
 	after sorting their results. This is useful to generate a file from multiple
 	files following a name convention.
 	Running the command without any arguments will trigger all hooks inside
-	"~/.carcassonne".
+	"~/.ore".
 	
 	Options:
 	    --help, -h           Displays this help message.
@@ -52,7 +52,7 @@ command_help ()
 	    want to output all ".ssh/config_*" files, "pattern" could be
 	    ".ssh/config_*".
 	
-	Send bugs and/or suggestions to https://github.com/augustohp/carcassonne/issues
+	Send bugs and/or suggestions to https://github.com/augustohp/ore/issues
 	EOT
 }
 

--- a/tests/01-Introduction.md
+++ b/tests/01-Introduction.md
@@ -1,4 +1,4 @@
-# Carcassonne Tests Introduction
+# Ore Tests Introduction
 
 All [code blocks][1] in `*.md` files are treated as tests by [clitest][2] and
 other text is ignored. Hopefully what is written between the tests is useful in
@@ -19,12 +19,12 @@ how to execute the tests manually.
 
 ## The binary used for tests
 
-As a *developer* running the test suite might already have `carcassonne`
+As a *developer* running the test suite might already have `ore`
 available on his `$PATH`, the `Makefile` symlinks the development file to
-`/tmp/carcassonne-dev` - which is used throughout test files.
+`/tmp/ore-dev` - which is used throughout test files.
 
-    $ which carcassonne-dev
-    /tmp/carcassonne-dev
+    $ which ore-dev
+    /tmp/ore-dev
 
 ## The tests
 
@@ -36,39 +36,39 @@ every command line program should follow.
 Displaying the version number of a program is a nice behaviour to provide, many
 programs test the existence of another through that interface.
 
-    $ carcassonne-dev -v
-    carcassonne-dev 1.0.0
-    $ carcassonne-dev --version
-    carcassonne-dev 1.0.0
+    $ ore-dev -v
+    ore-dev 1.0.0
+    $ ore-dev --version
+    ore-dev 1.0.0
 
 The name of the program is fetch from `$0`, so if the program is named
-`carcassonne-dev` that is what will be displayed.
+`ore-dev` that is what will be displayed.
 
 ### Getting help
 
 A help must be displayed as well, like `git` there are two versions: a *short*
 (`-h`) and a *long* (`--help`) one.
 
-    $ carcassonne-dev -h
-    Usage: carcassonne-dev [-v | --version] [-h | --help]
-           carcassonne-dev [-d <n=2> | --depth <n=2>] [-s <p> | --sort <p>] <pattern>
-           carcassonne-dev [-d | --files] <pattern>
-           carcassonne-dev [--hook <load|pre|post>]
+    $ ore-dev -h
+    Usage: ore-dev [-v | --version] [-h | --help]
+           ore-dev [-d <n=2> | --depth <n=2>] [-s <p> | --sort <p>] <pattern>
+           ore-dev [-d | --files] <pattern>
+           ore-dev [--hook <load|pre|post>]
 
 The *short help* provides examples of usage where each line is a command one
 might issue with the program.
 
-    $ carcassonne-dev --help
-    Usage: carcassonne-dev [options] <pattern>
-           carcassonne-dev [options]
-           carcassonne-dev <pattern>
-           carcassonne-dev
+    $ ore-dev --help
+    Usage: ore-dev [options] <pattern>
+           ore-dev [options]
+           ore-dev <pattern>
+           ore-dev
     
-    Carcassonne finds files following a "pattern" and outputs their content
+    Ore finds files following a "pattern" and outputs their content
     after sorting their results. This is useful to generate a file from multiple
     files following a name convention.
     Running the command without any arguments will trigger all hooks inside
-    "~/.carcassonne".
+    "~/.ore".
     
     Options:
         --help, -h           Displays this help message.
@@ -88,7 +88,7 @@ might issue with the program.
         want to output all ".ssh/config_*" files, "pattern" could be
         ".ssh/config_*".
     
-    Send bugs and/or suggestions to https://github.com/augustohp/carcassonne/issues
+    Send bugs and/or suggestions to https://github.com/augustohp/ore/issues
 
 The *full help* should provide everything a user need to know as no `man` pages
 are provided with the script.
@@ -97,24 +97,24 @@ are provided with the script.
 
 When an invalid option is provided, an error message should be displayed:
 
-    $ carcassonne-dev -x
-    Error: Unknown option "-x", try "carcassonne-dev --help".
+    $ ore-dev -x
+    Error: Unknown option "-x", try "ore-dev --help".
 
 These *invalid calls* should also exit with a proper *exit code*:
 
-    $ carcassonne-dev -x #=> --exit 2
+    $ ore-dev -x #=> --exit 2
 
 If a valid command such as `help` or `version` is passed and an invalid
 parameter is given, give preference for the valid command:
 
-    $ carcassonne-dev -h -x #=> --exit 0
-    $ carcassonne-dev -v -x #=> --exit 0
+    $ ore-dev -h -x #=> --exit 0
+    $ ore-dev -v -x #=> --exit 0
 
 ### Some improvements to the API
 
 Currently, options are parsed one at a time. We cannot specify all options with
 a single `-`:
 
-    $ carcassonne-dev -vx #=> --exit 2
+    $ ore-dev -vx #=> --exit 2
 
 The above should work by providing `-v` behavior as previous tests state.


### PR DESCRIPTION
Carcassonne is too big of a name and, as the following `sed`
substitutions shows, very error prone:

* s/carcassonne/ore/g
* s/carcarssonne/ore/g
* s/carcassone/ore/g

In case you want to reapply the `sed` command, you might need those:

* s/Carcassonne/Ore/g
* /github\.com\/topics/s/carcassone/castle-ore/
* /github\.com\/augustohp/s/carcassone/ore/

Along with realizing how much I like to repeat myself, some
little-last-hour improvements were made without breaking any
(un)existing behavior:

1. Makefile CARCASSONNE references exchanged by PROJECT
2. Makefile now calls variables and not the program directly
3. Makefile displays the `ln` and `$PATH` contents aiding debug
4. More exclusive GitHub topic `castle-ore`

Why `castle-ore` and not `ore` as GitHub topic
----------------------------------------------

Searching for compatible repositories is a *big feature* of the project
if adoption is a concern. "Carcassonne" is the name of a board game with
a bunch of projects around GitHub already, not much but the confusion
together with how difficult it is to write it made it easy to allow a
name change.

Using this project without the default behavior of "dotfile castles"
didn't make much sense as well. A install script would solve those
issues easily, without being compatible with how castles deal with
repetitive files - it makes sense to use that existing knowledge.

Carcassonne was a "city castle", analogous to merging castle files. I
though of "brick", "sand", "stone" and decided on "ore" for:

* It is the shortest word
* Has a "profit" meaning to it
* Is a mineral which can be stretched to the castle analogy :P

The sad part is that I don't know if I am happy with the name. I am
probably going to be unhappy if GitHub repositories start showing on the
topic search before I finish this.